### PR TITLE
fix reading actual angle of each cabin

### DIFF
--- a/rpLidar.h
+++ b/rpLidar.h
@@ -89,7 +89,7 @@ class rpLidar{
 	
 	private:
 	
-	stExpressDataPacket_t ExpressDataBuffer[79];	///<Storge to save the Data of an Express Scan
+	stExpressDataPacket_t ExpressDataBuffer[80];	///<Storge to save the Data of an Express Scan
 	uint16_t interestAngleLeft;		///< left border of needed angle 180-360°
 	uint16_t interestAngleRight;	///< right border of needed angle 0-180°
 
@@ -128,11 +128,11 @@ class rpLidar{
 	/**
 	 * Calculates the angle of each Cabin in an ExpressDataPacket
 	 *
-	 * @param pointer to the packet
-	 * @param current cabin
+	 * @param angle of the current and next cabin
+	 * @param current cabin index
 	 * @return calculated angle
 	 */	
-	double  calcAngle(stExpressDataPacket_t* _packets,uint16_t _k);
+	double  calcAngle(double angle1, double angle2, uint16_t _k);
 	
 	/**
 	 * Copy the data to new memory and calculate the true angle of each distance


### PR DESCRIPTION
This pull request fix the calculating method for actual reading of each cabin. For each packet, angle1 and angle2 are calculated once. They will be the reference for angles of the corresponding cabins.

The pull request increases the number of actual packets stored in the ExpressDataBuffer from 76 to 79, which leads to 120 additional data points for each round.

It also fixes 2 logics of method start() and ExpressDataToPointArray().